### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ def versions = [
     lombok             : '1.18.22',
     hmctsCcdClient     : '4.8.6',
     hmctsIdamJavaClient: '2.0.1',
-    hmctsLogging       : '5.1.5',
+    hmctsLogging       : '6.0.1',
     pmd                : '6.19.0',
     checkstyle         : '8.32'
 ]


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.