### PR TITLE
Remove helm-requirements from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,8 @@
 {
-  "enabledManagers": ["helm-requirements","gradle-wrapper"],
-  "labels": ["dependencies"],
-  "helm-requirements":
-  {
-    "fileMatch": ["\\Chart.yaml|requirements.yaml$"],
-    "aliases": {
-      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
-    }
-  }
+  "enabledManagers": [
+    "gradle-wrapper"
+  ],
+  "labels": [
+    "dependencies"
+  ]
 }

--- a/.github/renovate.json.bak
+++ b/.github/renovate.json.bak
@@ -1,0 +1,11 @@
+{
+  "enabledManagers": ["helm-requirements","gradle-wrapper"],
+  "labels": ["dependencies"],
+  "helm-requirements":
+  {
+    "fileMatch": ["\\Chart.yaml|requirements.yaml$"],
+    "aliases": {
+      "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+    }
+  }
+}


### PR DESCRIPTION
This PR removes the deprecated helm-requirements manager which is no longer needed. Please review and merge.